### PR TITLE
test: execute cannot be done twice in a day

### DIFF
--- a/test/autocompounder.test.ts
+++ b/test/autocompounder.test.ts
@@ -282,4 +282,10 @@ describe("AutoCompounder Automation Tests", function () {
     let { result } = await relayW3f.run();
     expect(result.canExec).to.equal(false);
   });
+  it("Cannot execute twice in a day", async () => {
+    await relayW3f.run();
+    time.increase(DAY - 1);
+    let { result } = await relayW3f.run();
+    expect(result.canExec).to.equal(false);
+  });
 });

--- a/test/autoconverter.test.ts
+++ b/test/autoconverter.test.ts
@@ -296,4 +296,11 @@ describe("AutoConverter Automation Tests", function () {
     let { result } = await relayW3f.run();
     expect(result.canExec).to.equal(false);
   });
+
+  it("Cannot execute twice in a day", async () => {
+    await relayW3f.run();
+    time.increase(DAY - 1);
+    let { result } = await relayW3f.run();
+    expect(result.canExec).to.equal(false);
+  });
 });

--- a/web3-functions/relay/index.ts
+++ b/web3-functions/relay/index.ts
@@ -85,8 +85,6 @@ Web3Function.onRun(async (context: Web3FunctionContext) => {
     console.log(`Timestamp is ${timestamp}`);
     let firstDayEnd = timestamp - (timestamp % WEEK) + DAY;
 
-    //TODO: Also check if function has been run in less then a day
-
     // Can only run on First Day of Epoch
     if (firstDayEnd < timestamp)
       return { canExec: false, message: `Not first day` };
@@ -102,6 +100,19 @@ Web3Function.onRun(async (context: Web3FunctionContext) => {
       registryAddr,
       provider
     );
+
+    // Also check if function has been run in less then a day
+    for (let compounderInfo of compounderInfos) {
+      let lastRunTimestamp = await compounderInfo.contract.keeperLastRun();
+      if (timestamp - lastRunTimestamp < DAY)
+        return { canExec: false, message: `Already run in last day` };
+    }
+
+    for (let converterInfo of converterInfos) {
+      let lastRunTimestamp = await converterInfo.contract.keeperLastRun();
+      if (timestamp - lastRunTimestamp < DAY)
+        return { canExec: false, message: `Already run in last day` };
+    }
   } catch (err) {
     return { canExec: false, message: `Rpc call failed ${err}` };
   }


### PR DESCRIPTION
Creating tests to not let the keepers execute more than once per day